### PR TITLE
Only actually enqueue scripts if the post uses FancyBox

### DIFF
--- a/inc/class-easyfancybox.php
+++ b/inc/class-easyfancybox.php
@@ -318,6 +318,10 @@ var easy_fancybox_auto=function(){setTimeout(function(){jQuery(\'a[class*="'.$tr
 		if ( !self::$add_scripts )
 			return;
 
+		global $post;
+		if ( !is_a( $post, 'WP_Post' ) || strpos( $post->post_content, 'class="fancybox"' ) === false )
+		    return;
+
 		global $wp_styles;
 		$min = ( defined('WP_DEBUG') && WP_DEBUG ) ? '' : '.min';
 

--- a/inc/translation-strings.php
+++ b/inc/translation-strings.php
@@ -71,7 +71,7 @@ __('(12 seconds)','easy-fancybox');
 
 /* Translators: %s is replaced by Easy FancyBox plugin title plus installation link */
 __('To use the Easy Fancybox Pro advanced options, please install %s.','easy-fancybox');
-__('Or disable the Easy Fancybox Pro plugin.','easy-fancybox');
+__('To use the Easy Fancybox Pro advanced options, please activate %s.', 'easy-fancybox');
 
 __( 'Notice: The current Easy FancyBox plugin version is not fully compatible with your version of the Pro extension. Some advanced options may not be functional.', 'easy-fancybox' );
 /* Translators: %s is replaced by a version number */

--- a/readme.txt
+++ b/readme.txt
@@ -502,7 +502,8 @@ Fix Jetpack Tiled Gallery compat + security issue reported by Jakob Hagl sba-res
 = 1.8.18 =
 * FIX: Jetpack Tiled Gallery block compatibility
 * Don't include mousewheel script by default
-* SECURITY: fixed failing color value sanitization + added inline styles output filter, issue reported by Jakob Hagl sba-research.org
+* SECURITY FIX: failing color value sanitization, issue reported by Jakob Hagl sba-research.org, CVE-2019-16524
+* NEW: inline styles output filter
 
 = 1.8.17 =
 * Pro compatibility messages


### PR DESCRIPTION
We can improve the runtime footprint of the plugin by only actually
enqueueing scripts and styles if needed. In particular, if the post at
hand uses no fancybox images, we don't need to do anything at all. I
considered three approaches to implementing this:

* My original idea was to check the post for whether it uses the
[fancybox] shortcode - this idea was quickly discarded once I noticed
that there is no such shortcode :-)

* The next-best idea was to scan the post content for FancyBox markup.
In particular, for HTML elements using the 'fancybox' class. This is
easy to do, but unfortunately requires calling strpos() on the
(potentially very long) post content.

* I also considered doing all checking on the client side, in
JavaScript. I.e. the scripts and stylesheets are not enqueued on the
server - instead, the client tests whether
'document.querySelector(".fancybox")' yields any hits: if so, all
scripts and styles are loaded dynamically. This seemed to require large
rewrites to the plugin though (and it also seems wasteful to do this on
the client).

Hence, I went for the second approach - which is what this commit
attempts to implement. I'm not too happy with it, but saw no other way
to check if the plugin is actually used by a post. I'd love to hear about
better ways!
